### PR TITLE
Change implode order from legacy signature

### DIFF
--- a/src/Tribe/REST/V1/Endpoints/Single_Attendee.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Attendee.php
@@ -359,7 +359,7 @@ class Tribe__Tickets__REST__V1__Endpoints__Single_Attendee
 				$error_message  = sprintf(
 					// Translators: %s - List of valid statuses.
 					__( 'Supported statuses for this attendee are: %s', 'event-tickets' ),
-					implode( $statuses, ' | ' )
+					implode( ' | ', $statuses )
 				);
 				return new WP_Error( 'invalid-attendee-status', $error_message, [ 'status' => 400 ] );
 			}


### PR DESCRIPTION
This plugin sets its minimum PHP version as 7.4 in the readme.txt.

As of PHP 7.4 `implode()` changes the order of its arguments from 'Array, Separator' to 'Separator, 'Array'.

As of PHP 8.0 the legacy order support is removed.

In preparation for a minimum version of PHP 8.0 this would fix the removed error while being compatible with the plugins current minimal version.